### PR TITLE
Fix Querying Indexing section

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -71,7 +71,7 @@ include::objectMapping/dirtyChecking.adoc[]
 [[queryIndexes]]
 === Querying Indexing
 
-include::objectMapping/queryIndexes.adoc[]
+include::querying/queryIndexes.adoc[]
 
 [[writeConcern]]
 === Customizing the WriteConcern


### PR DESCRIPTION
The [Querying Indexing](http://gorm.grails.org/latest/mongodb/manual/#queryIndexes) section is currently broken.
<img width="679" alt="screen shot 2017-01-31 at 8 53 00 am" src="https://cloud.githubusercontent.com/assets/7215257/22470925/6be6abc8-e796-11e6-8d31-db9cbf22a44d.png">
