### PR TITLE
rename session to MongoSession i MongoSpec to avoid naming collision

### DIFF
--- a/grails-plugin/src/main/groovy/grails/test/mongodb/MongoSpec.groovy
+++ b/grails-plugin/src/main/groovy/grails/test/mongodb/MongoSpec.groovy
@@ -35,7 +35,7 @@ abstract class MongoSpec extends Specification {
     MongoDatastore mongoDatastore
 
     @Shared
-    Session session
+    Session mongoSession
 
     /**
      * @return Obtains the mapping context
@@ -104,13 +104,13 @@ abstract class MongoSpec extends Specification {
 
     void setup() {
         boolean existing = mongoDatastore.hasCurrentSession()
-        session = existing ? mongoDatastore.currentSession : DatastoreUtils.bindSession(mongoDatastore.connect())
+        mongoSession = existing ? mongoDatastore.currentSession : DatastoreUtils.bindSession(mongoDatastore.connect())
     }
 
     void cleanup() {
         if (!mongoDatastore.hasCurrentSession()) {
             TransactionSynchronizationManager.unbindResource(mongoDatastore)
-            DatastoreUtils.closeSessionOrRegisterDeferredClose(session, mongoDatastore)
+            DatastoreUtils.closeSessionOrRegisterDeferredClose(mongoSession, mongoDatastore)
         }
     }
 


### PR DESCRIPTION
When using WebRequestUnitTest in grails4/groovy2.5 there is a naming collision which create a compilation error. See the issue here: https://github.com/grails/grails-core/issues/11270