### PR TITLE
Fix failing includes

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -70,6 +70,8 @@ asciidoctor {
                 'pluginVersion' : project.version,
                 'mongoDriverVersion': mongodbDriverVersion,
                 'sourcedir'     : "${project.rootDir}"
+
+    baseDirFollowsSourceDir()
 }
 
 task fetchSource {

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -7,7 +7,7 @@ Graeme Rocher, Burt Beckwith, Puneet Behl
 [[introduction]]
 == Introduction
 
-include::{includedir}/introduction.adoc[]
+include::introduction.adoc[]
 
 [[compatibility]]
 === Compatibility with GORM for Hibernate


### PR DESCRIPTION
Add baseDirFollowsSource() to asciidoctor configuration to fix includes not getting found.

Fixes grails/gorm-docs#19
Fixes #650 