### PR TITLE
docs: Remove mentioning of Fongo

### DIFF
--- a/docs/src/docs/asciidoc/testing.adoc
+++ b/docs/src/docs/asciidoc/testing.adoc
@@ -4,13 +4,19 @@ To write unit tests with MongoDB and Spock you can simply extend from `grails.te
 uses by default a `MongoClient` instance that connects to a MongoDB instance as defined in your configuration
 (by default, `localhost` and port `27017`, see <<gettingStarted>> for more details):
 
+It is preferable to use testcontainers to automatically run MongoDB in a containerized environment and not have to run a MongoDB instance locally. The following examples use testcontainers:
+
+[source,groovy]
+----
+include::{sourcedir}/examples/grails3-mongodb/src/test/groovy/functional/tests/EmbeddedMongoClient.groovy[]
+----
+
 [source,groovy]
 ----
 include::{sourcedir}/examples/grails3-mongodb/src/test/groovy/functional/tests/LocalMongoUnitSpec.groovy[tags=structure]
 ----
 
-You can also provide your own `MongoClient` instance to use something such as https://github.com/fakemongo/fongo[Fongo],
-as shown in the following example:
+You can also use your own low-level `MongoClient` instance, as shown in the following example:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Change text as the example test case no longer uses Fongo. Add the EmbeddedMongoClient trait to the documentation as the example is not complete without it. Mention that the test examples now use testcontainers.

Close #154