### PR TITLE
chore(releasenotes): update workflow configurations 

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,24 +1,117 @@
 name-template: $RESOLVED_VERSION
 tag-template: v$RESOLVED_VERSION
+pull-request:
+  title-templates:
+    fix: '🐛 $TITLE (#$NUMBER)'
+    feat: '🚀 $TITLE (#$NUMBER)'
+    default: '$TITLE (#$NUMBER)'
+autolabeler:
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'improvement'
+    branch:
+      - '/improv\/.+/'
+    title:
+      - '/improv/i'      
+  - label: 'feature'
+    branch:
+      - '/feature\/.+/'
+    title:
+      - '/feat/i'
+  - label: 'documentation'
+    branch:
+      - '/docs\/.+/'
+    title:
+      - '/docs/i'
+  - label: 'maintenance'
+    branch:
+      - '/(chore|refactor|style|test|ci|perf|build)\/.+/'
+    title:
+      - '/(chore|refactor|style|test|ci|perf|build)/i'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
+  - label: 'refactor'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/refactor/i'
+  - label: 'style'
+    branch:
+      - '/style\/.+/'
+    title:
+      - '/style/i'
+  - label: 'test'
+    branch:
+      - '/test\/.+/'
+    title:
+      - '/test/i'
+  - label: 'ci'
+    branch:
+      - '/ci\/.+/'
+    title:
+      - '/ci/i'
+  - label: 'perf'
+    branch:
+      - '/perf\/.+/'
+    title:
+      - '/perf/i'
+  - label: 'build'
+    branch:
+      - '/build\/.+/'
+    title:
+      - '/build/i'
+  - label: 'deps'
+    branch:
+      - '/deps\/.+/'
+    title:
+      - '/deps/i'
+  - label: 'revert'
+    branch:
+      - '/revert\/.+/'
+    title:
+      - '/revert/i'
 categories:
-  - title: ✨ Features
+  - title: '🚀 Features'
     labels:
+      - 'feat'
       - "type: enhancement"
       - "type: new feature"
       - "type: major"
-  - title: 🐛 Bug Fixes/Improvements
+      - "type: minor"      
+  - title: '💡 Improvements'
     labels:
+      - 'improvement'
       - "type: improvement"
+
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'      
+      - 'bug' 
       - "type: bug"
-      - "type: minor"
-  - title: 🛠 Dependency upgrades
+  - title: '📚 Documentation'
     labels:
-      - "type: dependency upgrade"
-      - "dependencies"
-  - title: ⚙️ Build/CI
+      - 'docs'
+  - title: '🔧 Maintenance'
     labels:
+      - 'maintenance'
+      - 'chore'
+      - 'refactor'
+      - 'style'
+      - 'test'
+      - 'ci'
+      - 'perf'
+      - 'build'
       - "type: ci"
       - "type: build"
+  - title: '⏪ Reverts'
+    labels:
+      - 'revert'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 version-resolver:
   major:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - '[6-9]+.[0-9]+.x'
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]               
   workflow_dispatch:
 jobs:
   release_notes:
@@ -15,18 +19,15 @@ jobs:
         id: check_release_drafter
         run: |
           has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo ::set-output name=has_release_drafter::${has_release_drafter}
+          echo "has_release_drafter=${has_release_drafter}" >> $GITHUB_OUTPUT
       - name: Extract branch name
         id: extract_branch
-        run: echo ::set-output name=value::${GITHUB_REF:11}
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       # If it has release drafter:
       - uses: release-drafter/release-drafter@v6
         if: steps.check_release_drafter.outputs.has_release_drafter == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          commitish: ${{ steps.extract_branch.outputs.value }}
-          filter-by-commitish: true
       # Otherwise:
       - name: Export Gradle Properties
         if: steps.check_release_drafter.outputs.has_release_drafter == 'false'


### PR DESCRIPTION
* Update release-drafter template configuration
* Add `pull_request` event is required only for autolabeler
* Add `pull_request_target` event is required for autolabeler to support PRs from forks