### PR TITLE
Add system property for TCK test control

### DIFF
--- a/grails-datastore-gorm-mongodb/build.gradle
+++ b/grails-datastore-gorm-mongodb/build.gradle
@@ -48,6 +48,9 @@ test {
         showExceptions true
         showStackTraces true
     }
+
+    // Used in the TCK test to selectively enable/disable tests
+    systemProperty('mongodb.gorm.suite', 'true')
 }
 
 test.doFirst {


### PR DESCRIPTION
Introduce a new system property, `mongodb.gorm.suite`, to manage the enabling or disabling of specific tests within the TCK.