### PR TITLE
Update example projects to set hibernate-ehcache dependency

### DIFF
--- a/examples/grails3-hibernate5-mongodb/build.gradle
+++ b/examples/grails3-hibernate5-mongodb/build.gradle
@@ -22,7 +22,13 @@ dependencies {
     runtimeOnly 'org.grails.plugins:scaffolding'
     runtimeOnly 'org.grails:grails-plugin-i18n'
     runtimeOnly 'org.grails:grails-plugin-url-mappings'
-    runtimeOnly 'org.hibernate:hibernate-ehcache'
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: "org.hibernate", module: "hibernate-core"
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'

--- a/examples/gson-templates/build.gradle
+++ b/examples/gson-templates/build.gradle
@@ -24,14 +24,6 @@ dependencies {
     runtimeOnly project(':views-json-templates')
     runtimeOnly 'com.bertramlabs.plugins:asset-pipeline-grails'
 
-    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
-        // exclude javax variant of hibernate-core
-        exclude group: "org.hibernate", module: "hibernate-core"
-    }
-    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
-        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
-    }
-
     integrationTestImplementation 'org.grails:grails-testing-support'
 }
 

--- a/examples/gson-templates/build.gradle
+++ b/examples/gson-templates/build.gradle
@@ -24,6 +24,14 @@ dependencies {
     runtimeOnly project(':views-json-templates')
     runtimeOnly 'com.bertramlabs.plugins:asset-pipeline-grails'
 
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: "org.hibernate", module: "hibernate-core"
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
+
     integrationTestImplementation 'org.grails:grails-testing-support'
 }
 

--- a/examples/gson-templates/grails-app/conf/application.yml
+++ b/examples/gson-templates/grails-app/conf/application.yml
@@ -69,13 +69,6 @@ grails:
                 taglib: none
                 staticparts: none
 ---
-hibernate:
-    cache:
-        queries: false
-        use_second_level_cache: false
-        use_query_cache: false
-        region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
-        
 endpoints:
     jmx:
         unique-names: true

--- a/examples/gson-templates/grails-app/conf/application.yml
+++ b/examples/gson-templates/grails-app/conf/application.yml
@@ -74,7 +74,7 @@ hibernate:
         queries: false
         use_second_level_cache: false
         use_query_cache: false
-        #region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
+        region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
         
 endpoints:
     jmx:

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ testcontainersMongodbVersion=1.20.1
 # for example apps only
 grailsSpringSecurityCoreVersion=7.0.0-SNAPSHOT
 grailsSpringSecurityRestVersion=6.0.0-SNAPSHOT
+hibernateVersion=5.6.15.Final
+jbossTransactionApiVersion=2.0.0.Final
 
 # This prevents the Grails Gradle Plugin from unnecessarily excluding slf4j-simple in the generated POMs
 # https://github.com/grails/grails-gradle-plugin/issues/222


### PR DESCRIPTION
While excluding hibernate-core (javax) and including jboss-transaction-api